### PR TITLE
Hot Chocolate v13

### DIFF
--- a/src/AppAny.HotChocolate.FluentValidation.csproj
+++ b/src/AppAny.HotChocolate.FluentValidation.csproj
@@ -34,7 +34,7 @@
 
   <ItemGroup Label="Packages">
     <PackageReference Include="FluentValidation" Version="11.1.1" />
-    <PackageReference Include="HotChocolate.Execution" Version="12.12.1" />
+    <PackageReference Include="HotChocolate.Execution" Version="13.0.0-preview.66" />
   </ItemGroup>
 
   <ItemGroup Label="Assets">

--- a/src/ValidationDefaults.cs
+++ b/src/ValidationDefaults.cs
@@ -107,7 +107,7 @@ namespace AppAny.HotChocolate.FluentValidation
       public static void Details(IErrorBuilder errorBuilder, ErrorMappingContext mappingContext)
       {
         errorBuilder
-          .SetExtension(ExtensionKeys.OperationKey, mappingContext.MiddlewareContext.Operation.Name?.Value)
+          .SetExtension(ExtensionKeys.OperationKey, mappingContext.MiddlewareContext.Operation.Name)
           .SetExtension(ExtensionKeys.FieldKey, mappingContext.MiddlewareContext.Selection.Field.Name)
           .SetExtension(ExtensionKeys.ArgumentKey, mappingContext.Argument.Name)
           .SetExtension(ExtensionKeys.PropertyKey, mappingContext.ValidationFailure.PropertyName)

--- a/tests/AppAny.HotChocolate.FluentValidation.Tests/MultipleMutations.cs
+++ b/tests/AppAny.HotChocolate.FluentValidation.Tests/MultipleMutations.cs
@@ -61,12 +61,12 @@ namespace AppAny.HotChocolate.FluentValidation.Tests
             field =>
             {
               Assert.Equal(ValidationDefaults.ExtensionKeys.FieldKey, field.Key);
-              Assert.Equal(new NameString("test"), field.Value);
+              Assert.Equal("test", field.Value);
             },
             argument =>
             {
               Assert.Equal(ValidationDefaults.ExtensionKeys.ArgumentKey, argument.Key);
-              Assert.Equal(new NameString("input"), argument.Value);
+              Assert.Equal("input", argument.Value);
             },
             property =>
             {
@@ -98,12 +98,12 @@ namespace AppAny.HotChocolate.FluentValidation.Tests
             field =>
             {
               Assert.Equal(ValidationDefaults.ExtensionKeys.FieldKey, field.Key);
-              Assert.Equal(new NameString("test"), field.Value);
+              Assert.Equal("test", field.Value);
             },
             argument =>
             {
               Assert.Equal(ValidationDefaults.ExtensionKeys.ArgumentKey, argument.Key);
-              Assert.Equal(new NameString("input"), argument.Value);
+              Assert.Equal("input", argument.Value);
             },
             property =>
             {

--- a/tests/AppAny.HotChocolate.FluentValidation.Tests/OverrideErrorMappers.cs
+++ b/tests/AppAny.HotChocolate.FluentValidation.Tests/OverrideErrorMappers.cs
@@ -133,12 +133,12 @@ namespace AppAny.HotChocolate.FluentValidation.Tests
             field =>
             {
               Assert.Equal(ValidationDefaults.ExtensionKeys.FieldKey, field.Key);
-              Assert.Equal(new NameString("test"), field.Value);
+              Assert.Equal("test", field.Value);
             },
             argument =>
             {
               Assert.Equal(ValidationDefaults.ExtensionKeys.ArgumentKey, argument.Key);
-              Assert.Equal(new NameString("input"), argument.Value);
+              Assert.Equal("input", argument.Value);
             },
             property =>
             {
@@ -197,12 +197,12 @@ namespace AppAny.HotChocolate.FluentValidation.Tests
             field =>
             {
               Assert.Equal(ValidationDefaults.ExtensionKeys.FieldKey, field.Key);
-              Assert.Equal(new NameString("test"), field.Value);
+              Assert.Equal("test", field.Value);
             },
             argument =>
             {
               Assert.Equal(ValidationDefaults.ExtensionKeys.ArgumentKey, argument.Key);
-              Assert.Equal(new NameString("input"), argument.Value);
+              Assert.Equal("input", argument.Value);
             },
             property =>
             {
@@ -261,12 +261,12 @@ namespace AppAny.HotChocolate.FluentValidation.Tests
             field =>
             {
               Assert.Equal(ValidationDefaults.ExtensionKeys.FieldKey, field.Key);
-              Assert.Equal(new NameString("test"), field.Value);
+              Assert.Equal("test", field.Value);
             },
             argument =>
             {
               Assert.Equal(ValidationDefaults.ExtensionKeys.ArgumentKey, argument.Key);
-              Assert.Equal(new NameString("input"), argument.Value);
+              Assert.Equal("input", argument.Value);
             },
             property =>
             {
@@ -358,12 +358,12 @@ namespace AppAny.HotChocolate.FluentValidation.Tests
             field =>
             {
               Assert.Equal(ValidationDefaults.ExtensionKeys.FieldKey, field.Key);
-              Assert.Equal(new NameString("test"), field.Value);
+              Assert.Equal("test", field.Value);
             },
             argument =>
             {
               Assert.Equal(ValidationDefaults.ExtensionKeys.ArgumentKey, argument.Key);
-              Assert.Equal(new NameString("input"), argument.Value);
+              Assert.Equal("input", argument.Value);
             },
             property =>
             {
@@ -458,12 +458,12 @@ namespace AppAny.HotChocolate.FluentValidation.Tests
             field =>
             {
               Assert.Equal(ValidationDefaults.ExtensionKeys.FieldKey, field.Key);
-              Assert.Equal(new NameString("test"), field.Value);
+              Assert.Equal("test", field.Value);
             },
             argument =>
             {
               Assert.Equal(ValidationDefaults.ExtensionKeys.ArgumentKey, argument.Key);
-              Assert.Equal(new NameString("input"), argument.Value);
+              Assert.Equal("input", argument.Value);
             },
             property =>
             {

--- a/tests/AppAny.HotChocolate.FluentValidation.Tests/OverrideUseFluentValidation.cs
+++ b/tests/AppAny.HotChocolate.FluentValidation.Tests/OverrideUseFluentValidation.cs
@@ -85,12 +85,12 @@ namespace AppAny.HotChocolate.FluentValidation.Tests
             field =>
             {
               Assert.Equal(ValidationDefaults.ExtensionKeys.FieldKey, field.Key);
-              Assert.Equal(new NameString("test"), field.Value);
+              Assert.Equal("test", field.Value);
             },
             argument =>
             {
               Assert.Equal(ValidationDefaults.ExtensionKeys.ArgumentKey, argument.Key);
-              Assert.Equal(new NameString("input"), argument.Value);
+              Assert.Equal("input", argument.Value);
             },
             property =>
             {

--- a/tests/AppAny.HotChocolate.FluentValidation.Tests/UsingAttributes.cs
+++ b/tests/AppAny.HotChocolate.FluentValidation.Tests/UsingAttributes.cs
@@ -147,12 +147,12 @@ namespace AppAny.HotChocolate.FluentValidation.Tests
             field =>
             {
               Assert.Equal(ValidationDefaults.ExtensionKeys.FieldKey, field.Key);
-              Assert.Equal(new NameString("test"), field.Value);
+              Assert.Equal("test", field.Value);
             },
             argument =>
             {
               Assert.Equal(ValidationDefaults.ExtensionKeys.ArgumentKey, argument.Key);
-              Assert.Equal(new NameString("input"), argument.Value);
+              Assert.Equal("input", argument.Value);
             },
             property =>
             {
@@ -205,12 +205,12 @@ namespace AppAny.HotChocolate.FluentValidation.Tests
             field =>
             {
               Assert.Equal(ValidationDefaults.ExtensionKeys.FieldKey, field.Key);
-              Assert.Equal(new NameString("test"), field.Value);
+              Assert.Equal("test", field.Value);
             },
             argument =>
             {
               Assert.Equal(ValidationDefaults.ExtensionKeys.ArgumentKey, argument.Key);
-              Assert.Equal(new NameString("input"), argument.Value);
+              Assert.Equal("input", argument.Value);
             },
             property =>
             {


### PR DESCRIPTION
This updates the tests to pass on the latest preview version of Hot Chocolate. These changes are _not_ backwards compatible with version 12.

It would be great to have a preview release of `AppAny.HotChocolate.FluentValidation`.

Closes #103.