### PR TITLE
Update HotChocolate to 13.0.0-preview.95

### DIFF
--- a/src/AppAny.HotChocolate.FluentValidation.csproj
+++ b/src/AppAny.HotChocolate.FluentValidation.csproj
@@ -34,7 +34,7 @@
 
   <ItemGroup Label="Packages">
     <PackageReference Include="FluentValidation" Version="11.1.1" />
-    <PackageReference Include="HotChocolate.Execution" Version="13.0.0-preview.66" />
+    <PackageReference Include="HotChocolate.Execution" Version="13.0.0-preview.95" />
   </ItemGroup>
 
   <ItemGroup Label="Assets">

--- a/src/Extensions/RequestExecutorBuilderExtensions.cs
+++ b/src/Extensions/RequestExecutorBuilderExtensions.cs
@@ -18,9 +18,7 @@ namespace AppAny.HotChocolate.FluentValidation
 
       builder.SetContextData(ValidationDefaults.ValidationOptionsKey, validationOptions);
 
-      builder.OnBeforeCompleteType(ValidationDefaults.Interceptors.OnBeforeCompleteType);
-
-      builder.OnAfterSchemaCreate(ValidationDefaults.Interceptors.OnAfterSchemaCreate);
+      builder.TryAddTypeInterceptor(ValidationDefaults.Interceptor);
 
       return builder;
     }

--- a/src/ValidationDefaults.cs
+++ b/src/ValidationDefaults.cs
@@ -7,7 +7,6 @@ global using FluentValidation;
 global using FluentValidation.Results;
 using System.Runtime.CompilerServices;
 using FluentValidation.Internal;
-using HotChocolate.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace AppAny.HotChocolate.FluentValidation
@@ -35,13 +34,9 @@ namespace AppAny.HotChocolate.FluentValidation
     public static FieldMiddleware Middleware { get; } = ValidationMiddlewares.Field;
 
     /// <summary>
-    ///   Default HotChocolate interceptors
+    ///   Default HotChocolate interceptor
     /// </summary>
-    public static class Interceptors
-    {
-      public static OnCompleteType OnBeforeCompleteType { get; } = ValidationInterceptors.OnBeforeCompleteType;
-      public static OnAfterSchemaCreate OnAfterSchemaCreate { get; } = ValidationInterceptors.OnAfterSchemaCreate;
-    }
+    public static Type Interceptor { get; } = typeof(ValidationInterceptor);
 
     /// <summary>
     ///   Default graphql error extensions keys

--- a/src/ValidationInterceptor.cs
+++ b/src/ValidationInterceptor.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Linq;
 using HotChocolate.Configuration;
 using HotChocolate.Types.Descriptors;
@@ -6,12 +5,11 @@ using HotChocolate.Types.Descriptors.Definitions;
 
 namespace AppAny.HotChocolate.FluentValidation
 {
-  internal sealed class ValidationInterceptors
+  internal sealed class ValidationInterceptor : TypeInterceptor
   {
-    public static void OnBeforeCompleteType(
+    public override void OnBeforeCompleteType(
       ITypeCompletionContext completionContext,
-      DefinitionBase? definition,
-      IDictionary<string, object?> contextData)
+      DefinitionBase? definition)
     {
       if (definition is not ObjectTypeDefinition objectTypeDefinition)
       {
@@ -43,7 +41,7 @@ namespace AppAny.HotChocolate.FluentValidation
       }
     }
 
-    public static void OnAfterSchemaCreate(IDescriptorContext descriptorContext, ISchema schema)
+    public override void OnAfterCreateSchema(IDescriptorContext descriptorContext, ISchema schema)
     {
       foreach (var objectField in schema.Types.OfType<IObjectType>().SelectMany(type => type.Fields))
       {

--- a/tests/AppAny.HotChocolate.FluentValidation.Benchmarks/EmptyInputsValidationBenchmarks.cs
+++ b/tests/AppAny.HotChocolate.FluentValidation.Benchmarks/EmptyInputsValidationBenchmarks.cs
@@ -26,10 +26,10 @@ namespace AppAny.HotChocolate.FluentValidation.Benchmarks
             .Argument("input", arg => arg.Type<TestInputType>().UseFluentValidation())))
           .Services.AddSingleton<IValidator<TestInput>, TestInputValidator>());
 
-      fairyBreadValidation = await BenchmarkSetup.CreateRequestExecutor(
-        builder => builder.AddFairyBread()
-          .AddMutationType(new TestMutationType(field => field.Argument("input", arg => arg.Type<TestInputType>())))
-          .Services.AddSingleton<TestInputValidator>().AddSingleton<IValidator<TestInput>, TestInputValidator>());
+      // fairyBreadValidation = await BenchmarkSetup.CreateRequestExecutor(
+      //   builder => builder.AddFairyBread()
+      //     .AddMutationType(new TestMutationType(field => field.Argument("input", arg => arg.Type<TestInputType>())))
+      //     .Services.AddSingleton<TestInputValidator>().AddSingleton<IValidator<TestInput>, TestInputValidator>());
     }
 
     [Benchmark]

--- a/tests/AppAny.HotChocolate.FluentValidation.Benchmarks/NullInputsValidationBenchmarks.cs
+++ b/tests/AppAny.HotChocolate.FluentValidation.Benchmarks/NullInputsValidationBenchmarks.cs
@@ -26,10 +26,10 @@ namespace AppAny.HotChocolate.FluentValidation.Benchmarks
             field.Argument("input", arg => arg.Type<TestInputType>().UseFluentValidation())))
           .Services.AddSingleton<IValidator<TestInput>, TestInputValidator>());
 
-      fairyBreadValidation = await BenchmarkSetup.CreateRequestExecutor(
-        builder => builder.AddFairyBread()
-          .AddMutationType(new TestMutationType(field => field.Argument("input", arg => arg.Type<TestInputType>())))
-          .Services.AddSingleton<TestInputValidator>().AddSingleton<IValidator<TestInput>, TestInputValidator>());
+      // fairyBreadValidation = await BenchmarkSetup.CreateRequestExecutor(
+      //   builder => builder.AddFairyBread()
+      //     .AddMutationType(new TestMutationType(field => field.Argument("input", arg => arg.Type<TestInputType>())))
+      //     .Services.AddSingleton<TestInputValidator>().AddSingleton<IValidator<TestInput>, TestInputValidator>());
     }
 
     [Benchmark]

--- a/tests/AppAny.HotChocolate.FluentValidation.Benchmarks/ScopedValidationBenchmarks.cs
+++ b/tests/AppAny.HotChocolate.FluentValidation.Benchmarks/ScopedValidationBenchmarks.cs
@@ -26,10 +26,10 @@ namespace AppAny.HotChocolate.FluentValidation.Benchmarks
             .Type<TestInputType>().UseFluentValidation(opt => opt.UseValidator<TestInputValidator>()))))
           .Services.AddScoped<TestInputValidator>());
 
-      fairyBreadValidation = await BenchmarkSetup.CreateRequestExecutor(
-        builder => builder.AddFairyBread()
-          .AddMutationType(new TestMutationType(field => field.Argument("input", arg => arg.Type<TestInputType>())))
-          .Services.AddScoped<TestInputValidator>().AddScoped<IValidator<TestInput>, TestInputValidator>());
+      // fairyBreadValidation = await BenchmarkSetup.CreateRequestExecutor(
+      //   builder => builder.AddFairyBread()
+      //     .AddMutationType(new TestMutationType(field => field.Argument("input", arg => arg.Type<TestInputType>())))
+      //     .Services.AddScoped<TestInputValidator>().AddScoped<IValidator<TestInput>, TestInputValidator>());
     }
 
     [Benchmark]

--- a/tests/AppAny.HotChocolate.FluentValidation.Benchmarks/SingletonValidationBenchmarks.cs
+++ b/tests/AppAny.HotChocolate.FluentValidation.Benchmarks/SingletonValidationBenchmarks.cs
@@ -26,10 +26,10 @@ namespace AppAny.HotChocolate.FluentValidation.Benchmarks
             .Type<TestInputType>().UseFluentValidation(opt => opt.UseValidator<TestInputValidator>()))))
           .Services.AddSingleton<TestInputValidator>());
 
-      fairyBreadValidation = await BenchmarkSetup.CreateRequestExecutor(
-        builder => builder.AddFairyBread()
-          .AddMutationType(new TestMutationType(field => field.Argument("input", arg => arg.Type<TestInputType>())))
-          .Services.AddSingleton<TestInputValidator>().AddSingleton<IValidator<TestInput>, TestInputValidator>());
+      // fairyBreadValidation = await BenchmarkSetup.CreateRequestExecutor(
+      //   builder => builder.AddFairyBread()
+      //     .AddMutationType(new TestMutationType(field => field.Argument("input", arg => arg.Type<TestInputType>())))
+      //     .Services.AddSingleton<TestInputValidator>().AddSingleton<IValidator<TestInput>, TestInputValidator>());
     }
 
     [Benchmark]


### PR DESCRIPTION
HotChocolate 13 preview 91 broke this library, due to changes with type interceptors. The extension methods on `IRequestExecutorBuilder` seem to have been removed, and there doesn't appear to be a `DelegateSchemaInterceptor` anymore.

I've replaced the static interceptor methods with a class extending `TypeInterceptor`.

1. Is the `ValidationDefaults` stuff correct?
2. I had to comment-out the Fairybread code in the benchmarks – how should that be handled?