### PR TITLE
FEAT: Support HotChocolate 15.1.

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Package | Setup
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 9.0.x
           include-prerelease: true
 
       - name: Package | Publish

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Tests | Setup
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 9.0.x
           include-prerelease: true
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/AppAny.HotChocolate.FluentValidation.csproj
+++ b/src/AppAny.HotChocolate.FluentValidation.csproj
@@ -34,7 +34,7 @@
 
   <ItemGroup Label="Packages">
     <PackageReference Include="FluentValidation" Version="11.11.0" />
-    <PackageReference Include="HotChocolate.Execution" Version="15.1.1" />
+    <PackageReference Include="HotChocolate.Execution" Version="15.1.3" />
   </ItemGroup>
 
   <ItemGroup Label="Assets">

--- a/src/AppAny.HotChocolate.FluentValidation.csproj
+++ b/src/AppAny.HotChocolate.FluentValidation.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -33,8 +33,8 @@
 <!--  </ItemGroup>-->
 
   <ItemGroup Label="Packages">
-    <PackageReference Include="FluentValidation" Version="11.10.0" />
-    <PackageReference Include="HotChocolate.Execution" Version="14.1.0" />
+    <PackageReference Include="FluentValidation" Version="11.11.0" />
+    <PackageReference Include="HotChocolate.Execution" Version="15.1.1" />
   </ItemGroup>
 
   <ItemGroup Label="Assets">

--- a/src/ValidationInterceptor.cs
+++ b/src/ValidationInterceptor.cs
@@ -41,6 +41,7 @@ namespace AppAny.HotChocolate.FluentValidation
       }
     }
 
+    [Obsolete]
     public override void OnAfterCreateSchema(IDescriptorContext descriptorContext, ISchema schema)
     {
       foreach (var objectField in schema.Types.OfType<IObjectType>().SelectMany(type => type.Fields))

--- a/tests/AppAny.HotChocolate.FluentValidation.Benchmarks/AppAny.HotChocolate.FluentValidation.Benchmarks.csproj
+++ b/tests/AppAny.HotChocolate.FluentValidation.Benchmarks/AppAny.HotChocolate.FluentValidation.Benchmarks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <OutputType>Exe</OutputType>
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
-    <PackageReference Include="FairyBread" Version="10.0.0" />
+    <PackageReference Include="FairyBread" Version="11.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/AppAny.HotChocolate.FluentValidation.Tests/AppAny.HotChocolate.FluentValidation.Tests.csproj
+++ b/tests/AppAny.HotChocolate.FluentValidation.Tests/AppAny.HotChocolate.FluentValidation.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <LangVersion>preview</LangVersion>


### PR DESCRIPTION
Support HotChocolate 15.1. Hotchocolate requires net8.0 or net9.0 and no longer supports either netstandard2.0 or netstandard2.1. Also bumped FluentValidation library version. 